### PR TITLE
Add group dropdown to checkout form

### DIFF
--- a/frontend/src/api/order.client.ts
+++ b/frontend/src/api/order.client.ts
@@ -14,6 +14,7 @@ export interface OrderDetails {
     first_name: string,
     last_name: string,
     email: string,
+    group?: string,
 }
 
 export interface AttendeeDetails extends OrderDetails {

--- a/frontend/src/components/routes/product-widget/CollectInformation/index.tsx
+++ b/frontend/src/components/routes/product-widget/CollectInformation/index.tsx
@@ -65,6 +65,7 @@ export const CollectInformation = () => {
                 first_name: "",
                 last_name: "",
                 email: "",
+                group: "",
                 address: {},
                 questions: {},
             },
@@ -298,6 +299,18 @@ export const CollectInformation = () => {
                         label={t`Email Address`}
                         placeholder={t`Email Address`}
                         {...form.getInputProps("order.email")}
+                    />
+
+                    <NativeSelect
+                        withAsterisk
+                        label={t`Gruppe`}
+                        data={[
+                            { value: 'Hauptgruppe', label: t`Hauptgruppe` },
+                            { value: 'Nachwuchs', label: t`Nachwuchs` },
+                            { value: 'Umfeld', label: t`Umfeld` },
+                            { value: 'Interesse', label: t`Interesse` },
+                        ]}
+                        {...form.getInputProps("order.group")}
                     />
 
                     {orderRequiresAttendeeDetails && (


### PR DESCRIPTION
## Summary
- extend OrderDetails to support `group`
- collect group selection during ticket purchase

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684a9dc95bd483259173c8d60a0ea89b