### PR TITLE
Update env for new domain

### DIFF
--- a/docker/all-in-one/.env
+++ b/docker/all-in-one/.env
@@ -3,8 +3,8 @@ APP_KEY=
 JWT_SECRET=
 
 # Frontend variables (Always prefixed with VITE_)
-VITE_FRONTEND_URL=http://localhost:8123
-VITE_API_URL_CLIENT=http://localhost:8123/api
+VITE_FRONTEND_URL=https://dreisamflora2-u47824.vm.elestio.app
+VITE_API_URL_CLIENT=https://dreisamflora2-u47824.vm.elestio.app/api
 VITE_API_URL_SERVER=http://localhost:80/api
 VITE_STRIPE_PUBLISHABLE_KEY=pk_test_123456789
 
@@ -16,8 +16,8 @@ LOG_CHANNEL=stderr
 QUEUE_CONNECTION=sync
 
 # Application settings
-APP_CDN_URL=http://localhost:8123/storage
-APP_FRONTEND_URL=http://localhost:8123
+APP_CDN_URL=https://dreisamflora2-u47824.vm.elestio.app/storage
+APP_FRONTEND_URL=https://dreisamflora2-u47824.vm.elestio.app
 APP_DISABLE_REGISTRATION=false
 APP_SAAS_MODE_ENABLED=false
 APP_SAAS_STRIPE_APPLICATION_FEE_PERCENT=0


### PR DESCRIPTION
## Summary
- update `docker/all-in-one/.env` to use `https://dreisamflora2-u47824.vm.elestio.app`

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684ac487c9f88325bb4770ff021cbdae